### PR TITLE
Move go module to github.com/crc-org/admin-helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BINARY_NAME := crc-admin-helper
 RELEASE_DIR ?= release
 GOLANGCI_LINT_VERSION = v1.47.0
 
-LDFLAGS := -X github.com/code-ready/admin-helper/pkg/constants.Version=$(VERSION) -extldflags='-static' -s -w $(GO_LDFLAGS)
+LDFLAGS := -X github.com/crc-org/admin-helper/pkg/constants.Version=$(VERSION) -extldflags='-static' -s -w $(GO_LDFLAGS)
 
 # Add default target
 .PHONY: all

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 build: off
 
-clone_folder: c:\gopath\src\github.com\code-ready\admin-helper
+clone_folder: c:\gopath\src\github.com\crc-org\admin-helper
 
 environment:
   GOPATH: c:\gopath

--- a/cmd/admin-helper/add.go
+++ b/cmd/admin-helper/add.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/code-ready/admin-helper/pkg/hosts"
+	"github.com/crc-org/admin-helper/pkg/hosts"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/admin-helper/clean.go
+++ b/cmd/admin-helper/clean.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/code-ready/admin-helper/pkg/hosts"
+	"github.com/crc-org/admin-helper/pkg/hosts"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/admin-helper/contains.go
+++ b/cmd/admin-helper/contains.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/code-ready/admin-helper/pkg/hosts"
+	"github.com/crc-org/admin-helper/pkg/hosts"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/admin-helper/daemon.go
+++ b/cmd/admin-helper/daemon.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/code-ready/admin-helper/pkg/api"
-	"github.com/code-ready/admin-helper/pkg/hosts"
+	"github.com/crc-org/admin-helper/pkg/api"
+	"github.com/crc-org/admin-helper/pkg/hosts"
 	"github.com/kardianos/service"
 	"github.com/spf13/cobra"
 )

--- a/cmd/admin-helper/main.go
+++ b/cmd/admin-helper/main.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/code-ready/admin-helper/pkg/constants"
+	"github.com/crc-org/admin-helper/pkg/constants"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/admin-helper/remove.go
+++ b/cmd/admin-helper/remove.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/code-ready/admin-helper/pkg/hosts"
+	"github.com/crc-org/admin-helper/pkg/hosts"
 	"github.com/spf13/cobra"
 )
 

--- a/crc-admin-helper.spec.in
+++ b/crc-admin-helper.spec.in
@@ -1,5 +1,5 @@
-# https://github.com/code-ready/admin-helper
-%global goipath         github.com/code-ready/admin-helper
+# https://github.com/crc-org/admin-helper
+%global goipath         github.com/crc-org/admin-helper
 %global goname          crc-admin-helper
 Version:                0.0.11
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/code-ready/admin-helper
+module github.com/crc-org/admin-helper
 
 go 1.17
 

--- a/pkg/api/mux.go
+++ b/pkg/api/mux.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/code-ready/admin-helper/pkg/constants"
-	"github.com/code-ready/admin-helper/pkg/hosts"
-	"github.com/code-ready/admin-helper/pkg/types"
+	"github.com/crc-org/admin-helper/pkg/constants"
+	"github.com/crc-org/admin-helper/pkg/hosts"
+	"github.com/crc-org/admin-helper/pkg/types"
 )
 
 func Mux(hosts *hosts.Hosts) http.Handler {

--- a/pkg/api/mux_test.go
+++ b/pkg/api/mux_test.go
@@ -5,8 +5,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/code-ready/admin-helper/pkg/client"
-	"github.com/code-ready/admin-helper/pkg/constants"
+	"github.com/crc-org/admin-helper/pkg/client"
+	"github.com/crc-org/admin-helper/pkg/constants"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/code-ready/admin-helper/pkg/types"
+	"github.com/crc-org/admin-helper/pkg/types"
 )
 
 type Client struct {

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,4 +1,4 @@
-module github.com/code-ready/crc/tools
+module github.com/crc-org/admin-helper
 
 go 1.17
 


### PR DESCRIPTION
This reflects the new location of the git repository.
This is being done because the code-ready branding is deprecated.