### PR TITLE
Fix another hosts.Remove() issue

### DIFF
--- a/pkg/hosts/hosts.go
+++ b/pkg/hosts/hosts.go
@@ -196,7 +196,8 @@ func (h *Hosts) Remove(hosts []string) error {
 				continue
 			}
 
-			for hostIdx, hostname := range line.Hostnames {
+			for hostIdx := len(line.Hostnames) - 1; hostIdx >= 0; hostIdx-- {
+				hostname := line.Hostnames[hostIdx]
 				if _, ok := hostEntries[hostname]; ok {
 					h.removeHostFromLine(line, hostIdx, i)
 				}

--- a/pkg/hosts/hosts.go
+++ b/pkg/hosts/hosts.go
@@ -190,7 +190,7 @@ func (h *Hosts) Remove(hosts []string) error {
 	defer h.Unlock()
 	// delete from CRC section
 	if start > 0 && end > 0 {
-		for i := start; i < end; i++ {
+		for i := end - 1; i >= start; i-- {
 			line := h.File.GetHostsFileLineByRow(i)
 			if line.Type == libhosty.LineTypeComment {
 				continue

--- a/pkg/hosts/hosts.go
+++ b/pkg/hosts/hosts.go
@@ -173,6 +173,17 @@ func (h *Hosts) Remove(hosts []string) error {
 		return err
 	}
 
+	uniqueHosts := map[string]bool{}
+	for i := 0; i < len(hosts); i++ {
+		uniqueHosts[hosts[i]] = true
+	}
+
+	var hostEntries = make(map[string]struct{}, len(uniqueHosts))
+
+	for key := range uniqueHosts {
+		hostEntries[key] = struct{}{}
+	}
+
 	start, end := h.findCrcSection()
 
 	h.Lock()
@@ -185,13 +196,11 @@ func (h *Hosts) Remove(hosts []string) error {
 				continue
 			}
 
-			for _, hostToRemove := range hosts {
-				for hostIdx, hostname := range line.Hostnames {
-					if hostname == hostToRemove {
-						h.removeHostFromLine(line, hostIdx, i)
-						break
-					}
+			for hostIdx, hostname := range line.Hostnames {
+				if _, ok := hostEntries[hostname]; ok {
+					h.removeHostFromLine(line, hostIdx, i)
 				}
+
 			}
 		}
 	} else {

--- a/pkg/hosts/hosts.go
+++ b/pkg/hosts/hosts.go
@@ -173,14 +173,8 @@ func (h *Hosts) Remove(hosts []string) error {
 		return err
 	}
 
-	uniqueHosts := map[string]bool{}
-	for i := 0; i < len(hosts); i++ {
-		uniqueHosts[hosts[i]] = true
-	}
-
-	var hostEntries = make(map[string]struct{}, len(uniqueHosts))
-
-	for key := range uniqueHosts {
+	var hostEntries = make(map[string]struct{})
+	for _, key := range hosts {
 		hostEntries[key] = struct{}{}
 	}
 

--- a/pkg/hosts/hosts_test.go
+++ b/pkg/hosts/hosts_test.go
@@ -282,6 +282,22 @@ func TestRemoveMultipleLines(t *testing.T) {
 	assert.Equal(t, hostsTemplate+eol()+crcSection(), string(content))
 }
 
+func TestRemoveMultipleNoCrcSection(t *testing.T) {
+	dir, err := os.MkdirTemp("", "hosts")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	hostsFile := filepath.Join(dir, "hosts")
+	assert.NoError(t, os.WriteFile(hostsFile, []byte("192.168.130.11   entry1 entry2"+eol()+"192.168.130.11   entry3 entry4"), 0600))
+	host := hosts(t, hostsFile)
+
+	assert.NoError(t, host.Remove([]string{"entry1", "entry2", "entry3", "entry4"}))
+
+	content, err := os.ReadFile(hostsFile)
+	assert.NoError(t, err)
+	assert.Equal(t, "", string(content))
+}
+
 func hosts(t *testing.T, hostsFile string) Hosts {
 	config, _ := libhosty.NewHostsFileConfig(hostsFile)
 	file, err := libhosty.InitWithConfig(config)

--- a/pkg/hosts/hosts_test.go
+++ b/pkg/hosts/hosts_test.go
@@ -244,6 +244,10 @@ func TestDeleteSliceBoundErrorOnRemove(t *testing.T) {
 	host := hosts(t, hostsFile)
 
 	assert.NoError(t, host.Remove([]string{"api.crc.testing", "oauth-openshift.apps-crc.testing", "console-openshift-console.apps-crc.testing", "downloads-openshift-console.apps-crc.testing", "canary-openshift-ingress-canary.apps-crc.testing", "default-route-openshift-image-registry.apps-crc.testing"}))
+
+	content, err := os.ReadFile(hostsFile)
+	assert.NoError(t, err)
+	assert.Equal(t, hostsTemplate+eol()+crcSection(), string(content))
 }
 
 func hosts(t *testing.T, hostsFile string) Hosts {
@@ -266,5 +270,9 @@ func eol() string {
 }
 
 func crcSection(lines ...string) string {
-	return fmt.Sprintf("# Added by CRC"+eol()+"%s"+eol()+"# End of CRC section", strings.Join(lines, eol()))
+	var content = ""
+	if len(lines) != 0 {
+		content = strings.Join(lines, eol()) + eol()
+	}
+	return fmt.Sprintf("# Added by CRC"+eol()+"%s"+"# End of CRC section", content)
 }

--- a/pkg/hosts/hosts_test.go
+++ b/pkg/hosts/hosts_test.go
@@ -266,6 +266,22 @@ func TestRemoveMultipleBackwardsSameLine(t *testing.T) {
 	assert.Equal(t, hostsTemplate+eol()+crcSection(), string(content))
 }
 
+func TestRemoveMultipleLines(t *testing.T) {
+	dir, err := os.MkdirTemp("", "hosts")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	hostsFile := filepath.Join(dir, "hosts")
+	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+crcSection("192.168.130.11   api.crc.testing", "192.168.130.11    oauth-openshift.apps-crc.testing")), 0600))
+	host := hosts(t, hostsFile)
+
+	assert.NoError(t, host.Remove([]string{"api.crc.testing", "oauth-openshift.apps-crc.testing"}))
+
+	content, err := os.ReadFile(hostsFile)
+	assert.NoError(t, err)
+	assert.Equal(t, hostsTemplate+eol()+crcSection(), string(content))
+}
+
 func hosts(t *testing.T, hostsFile string) Hosts {
 	config, _ := libhosty.NewHostsFileConfig(hostsFile)
 	file, err := libhosty.InitWithConfig(config)

--- a/pkg/hosts/hosts_test.go
+++ b/pkg/hosts/hosts_test.go
@@ -22,11 +22,7 @@ const (
 )
 
 func TestAdd(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(`127.0.0.1 entry1`), 0600))
 
 	host := hosts(t, hostsFile)
@@ -40,11 +36,7 @@ func TestAdd(t *testing.T) {
 }
 
 func TestAddMoreThen9Hosts(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate), 0600))
 
 	host := hosts(t, hostsFile)
@@ -57,11 +49,7 @@ func TestAddMoreThen9Hosts(t *testing.T) {
 }
 
 func TestAddMoreThan18Hosts(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate), 0600))
 
 	host := hosts(t, hostsFile)
@@ -75,11 +63,7 @@ func TestAddMoreThan18Hosts(t *testing.T) {
 }
 
 func TestAddMoreThen9HostsInMultipleLines(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+crcSection("127.0.0.1        entry1 entry10 entry2 entry3 entry4 entry5 entry6 entry7", "127.0.0.1        entry11 entry12 entry13 entry14 entry15 entry16 entry17 entry18")+eol()), 0600))
 
 	host := hosts(t, hostsFile)
@@ -92,11 +76,7 @@ func TestAddMoreThen9HostsInMultipleLines(t *testing.T) {
 }
 
 func TestRemove(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate), 0600))
 
 	host := hosts(t, hostsFile)
@@ -110,11 +90,7 @@ func TestRemove(t *testing.T) {
 }
 
 func TestClean(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+crcSection("127.0.0.1 entry1.suffix1 entry2.suffix2")), 0600))
 
 	host := hosts(t, hostsFile)
@@ -127,11 +103,7 @@ func TestClean(t *testing.T) {
 }
 
 func TestCleanWithoutCrcSection(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate), 0600))
 
 	host := hosts(t, hostsFile)
@@ -144,11 +116,7 @@ func TestCleanWithoutCrcSection(t *testing.T) {
 }
 
 func TestContains(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(`127.0.0.1 entry1.suffix1 entry2.suffix2`), 0600))
 
 	host := hosts(t, hostsFile)
@@ -159,11 +127,7 @@ func TestContains(t *testing.T) {
 }
 
 func TestSuffixFilter(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(`127.0.0.1 localhost localhost.localdomain`), 0600))
 
 	config, _ := libhosty.NewHostsFileConfig(hostsFile)
@@ -184,11 +148,7 @@ func TestSuffixFilter(t *testing.T) {
 }
 
 func TestAddMoreThan9HostsWithFullLine(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+crcSection("127.0.0.1        entry1  entry2 entry3 entry4 entry5 entry6 entry7 entry8 entry9")+eol()), 0600))
 
 	host := hosts(t, hostsFile)
@@ -201,11 +161,7 @@ func TestAddMoreThan9HostsWithFullLine(t *testing.T) {
 }
 
 func TestAddMoreThan9HostsWithOverfullLine(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+crcSection("127.0.0.1        entry1  entry2 entry3 entry4 entry5 entry6 entry7 entry8 entry9 entry10")+eol()), 0600))
 
 	host := hosts(t, hostsFile)
@@ -218,11 +174,7 @@ func TestAddMoreThan9HostsWithOverfullLine(t *testing.T) {
 }
 
 func TestRemoveOnOldHostFile(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+"127.0.0.1 entry1 entry2"), 0600))
 
 	host := hosts(t, hostsFile)
@@ -235,11 +187,7 @@ func TestRemoveOnOldHostFile(t *testing.T) {
 }
 
 func TestRemoveMultipleForwardSameLine(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+crcSection("192.168.130.11   entry1 entry2")), 0600))
 	host := hosts(t, hostsFile)
 
@@ -251,11 +199,7 @@ func TestRemoveMultipleForwardSameLine(t *testing.T) {
 }
 
 func TestRemoveMultipleBackwardsSameLine(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+crcSection("192.168.130.11   entry1 entry2")), 0600))
 	host := hosts(t, hostsFile)
 
@@ -267,11 +211,7 @@ func TestRemoveMultipleBackwardsSameLine(t *testing.T) {
 }
 
 func TestRemoveMultipleLines(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+crcSection("192.168.130.11   api.crc.testing", "192.168.130.11    oauth-openshift.apps-crc.testing")), 0600))
 	host := hosts(t, hostsFile)
 
@@ -283,11 +223,7 @@ func TestRemoveMultipleLines(t *testing.T) {
 }
 
 func TestRemoveMultipleNoCrcSection(t *testing.T) {
-	dir, err := os.MkdirTemp("", "hosts")
-	assert.NoError(t, err)
-	defer os.RemoveAll(dir)
-
-	hostsFile := filepath.Join(dir, "hosts")
+	hostsFile := filepath.Join(t.TempDir(), "hosts")
 	assert.NoError(t, os.WriteFile(hostsFile, []byte("192.168.130.11   entry1 entry2"+eol()+"192.168.130.11   entry3 entry4"), 0600))
 	host := hosts(t, hostsFile)
 

--- a/pkg/hosts/hosts_test.go
+++ b/pkg/hosts/hosts_test.go
@@ -250,6 +250,22 @@ func TestRemoveMultipleForwardSameLine(t *testing.T) {
 	assert.Equal(t, hostsTemplate+eol()+crcSection(), string(content))
 }
 
+func TestRemoveMultipleBackwardsSameLine(t *testing.T) {
+	dir, err := os.MkdirTemp("", "hosts")
+	assert.NoError(t, err)
+	defer os.RemoveAll(dir)
+
+	hostsFile := filepath.Join(dir, "hosts")
+	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+crcSection("192.168.130.11   entry1 entry2")), 0600))
+	host := hosts(t, hostsFile)
+
+	assert.NoError(t, host.Remove([]string{"entry2", "entry1"}))
+
+	content, err := os.ReadFile(hostsFile)
+	assert.NoError(t, err)
+	assert.Equal(t, hostsTemplate+eol()+crcSection(), string(content))
+}
+
 func hosts(t *testing.T, hostsFile string) Hosts {
 	config, _ := libhosty.NewHostsFileConfig(hostsFile)
 	file, err := libhosty.InitWithConfig(config)

--- a/pkg/hosts/hosts_test.go
+++ b/pkg/hosts/hosts_test.go
@@ -234,16 +234,16 @@ func TestRemoveOnOldHostFile(t *testing.T) {
 	assert.Equal(t, hostsTemplate, string(content))
 }
 
-func TestDeleteSliceBoundErrorOnRemove(t *testing.T) {
+func TestRemoveMultipleForwardSameLine(t *testing.T) {
 	dir, err := os.MkdirTemp("", "hosts")
 	assert.NoError(t, err)
 	defer os.RemoveAll(dir)
 
 	hostsFile := filepath.Join(dir, "hosts")
-	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+crcSection("192.168.130.11   api.crc.testing canary-openshift-ingress-canary.apps-crc.testing console-openshift-console.apps-crc.testing default-route-openshift-image-registry.apps-crc.testing downloads-openshift-console.apps-crc.testing oauth-openshift.apps-crc.testing")), 0600))
+	assert.NoError(t, os.WriteFile(hostsFile, []byte(hostsTemplate+eol()+crcSection("192.168.130.11   entry1 entry2")), 0600))
 	host := hosts(t, hostsFile)
 
-	assert.NoError(t, host.Remove([]string{"api.crc.testing", "oauth-openshift.apps-crc.testing", "console-openshift-console.apps-crc.testing", "downloads-openshift-console.apps-crc.testing", "canary-openshift-ingress-canary.apps-crc.testing", "default-route-openshift-image-registry.apps-crc.testing"}))
+	assert.NoError(t, host.Remove([]string{"entry1", "entry2"}))
 
 	content, err := os.ReadFile(hostsFile)
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR reworks the hosts.Remove() fix which was done in 0.5.1 to make it more
efficient, and consistent with a second fix done in this PR.
We have issues with hosts.Remove() both when removing entries from a single
line, but also when the removal of host entries empties some lines and causes
their removal.
0.5.1 fixed the former but not the latter. This PR should fix both, and adds
test cases for the second issue.