### PR TITLE
spec: add ppc64le to the list of arches to build for

### DIFF
--- a/crc-admin-helper.spec.in
+++ b/crc-admin-helper.spec.in
@@ -3,7 +3,7 @@
 %global goname          crc-admin-helper
 Version:                0.5.4
 
-%global golang_arches x86_64 aarch64
+%global golang_arches x86_64 aarch64 ppc64le
 %gometa
 
 %global gobuilddir %{_builddir}/%{archivename}/_build
@@ -18,13 +18,6 @@ CRC's helper with administrative privileges}
 
 %global golicenses    LICENSE
 %global godocs        *.md
-
-%ifarch x86_64
-%global gohostarch  amd64
-%endif
-%ifarch aarch64
-%global gohostarch  arm64
-%endif
 
 Name:           %{goname}
 Release:        1%{?dist}
@@ -60,7 +53,7 @@ make VERSION=%{version} GO_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr
 %install
 # with fedora macros: gopkginstall
 install -m 0755 -vd                     %{buildroot}%{_bindir}
-install -m 0755 -vp %{gobuilddir}/src/%{goipath}/out/linux-%{gohostarch}/crc-admin-helper %{buildroot}%{_bindir}/
+install -m 0755 -vp %{gobuilddir}/src/%{goipath}/out/linux-amd64/crc-admin-helper %{buildroot}%{_bindir}/
 
 install -d %{buildroot}%{_datadir}/%{name}-redistributable/{linux,macos,windows}
 install -m 0755 -vp %{gobuilddir}/src/%{goipath}/out/linux-amd64/crc-admin-helper %{buildroot}%{_datadir}/%{name}-redistributable/linux/%{name}-amd64


### PR DESCRIPTION
the crc rpm depends on this rpm and it also builds on the ppc64le arch, and the crc rpm fails to build since its unable to find the admin-helper rpm when building on ppc64le

this also installs only the amd64 arch specific binary in all arches as we are not installing the rpm but using it to just build