### PR TITLE
feat: enable release of binaries for of s390x architecture

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ $(BUILD_DIR)/linux-amd64/$(BINARY_NAME):
 $(BUILD_DIR)/linux-arm64/$(BINARY_NAME):
 	CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags="$(LDFLAGS)" -o $@ $(GO_BUILDFLAGS) ./cmd/admin-helper/
 
+$(BUILD_DIR)/linux-s390x/$(BINARY_NAME):
+	CGO_ENABLED=0 GOOS=linux GOARCH=s390x go build -ldflags="$(LDFLAGS)" -o $@ $(GO_BUILDFLAGS) ./cmd/admin-helper/
+
 $(BUILD_DIR)/windows-amd64/$(BINARY_NAME).exe:
 	CGO_ENABLED=0 GOARCH=amd64 GOOS=windows go build -ldflags="$(LDFLAGS)" -o $@ $(GO_BUILDFLAGS) ./cmd/admin-helper/
 
@@ -51,7 +54,7 @@ $(BUILD_DIR)/macos-universal/$(BINARY_NAME): $(BUILD_DIR)/macos-amd64/$(BINARY_N
 	cd $(BUILD_DIR) && $(TOOLS_BINDIR)/makefat macos-universal/$(BINARY_NAME) macos-amd64/$(BINARY_NAME) macos-arm64/$(BINARY_NAME)
 
 .PHONY: cross ## Cross compiles all binaries
-cross: $(BUILD_DIR)/macos-amd64/$(BINARY_NAME) $(BUILD_DIR)/macos-arm64/$(BINARY_NAME) $(BUILD_DIR)/linux-amd64/$(BINARY_NAME) $(BUILD_DIR)/linux-arm64/$(BINARY_NAME) $(BUILD_DIR)/windows-amd64/$(BINARY_NAME).exe
+cross: $(BUILD_DIR)/macos-amd64/$(BINARY_NAME) $(BUILD_DIR)/macos-arm64/$(BINARY_NAME) $(BUILD_DIR)/linux-amd64/$(BINARY_NAME) $(BUILD_DIR)/linux-arm64/$(BINARY_NAME) $(BUILD_DIR)/linux-s390x/$(BINARY_NAME) $(BUILD_DIR)/windows-amd64/$(BINARY_NAME).exe
 
 .PHONY: macos-universal ## Creates macOS universal binary
 macos-universal: lint test $(BUILD_DIR)/macos-universal/$(BINARY_NAME)
@@ -61,6 +64,7 @@ release: clean lint test cross macos-universal
 	mkdir $(RELEASE_DIR)
 	cp $(BUILD_DIR)/linux-amd64/$(BINARY_NAME) $(RELEASE_DIR)/$(BINARY_NAME)-linux-amd64
 	cp $(BUILD_DIR)/linux-arm64/$(BINARY_NAME) $(RELEASE_DIR)/$(BINARY_NAME)-linux-arm64
+	cp $(BUILD_DIR)/linux-s390x/$(BINARY_NAME) $(RELEASE_DIR)/$(BINARY_NAME)-linux-s390x
 	cp $(BUILD_DIR)/macos-universal/$(BINARY_NAME) $(RELEASE_DIR)/$(BINARY_NAME)-darwin
 	cp $(BUILD_DIR)/windows-amd64/$(BINARY_NAME).exe $(RELEASE_DIR)/$(BINARY_NAME)-windows.exe
 	pushd $(RELEASE_DIR) && sha256sum * > sha256sum.txt && popd


### PR DESCRIPTION
This change enables the release of admin-helper binaries for the s390x architecture, which is a prerequisite for CRC to run on this platform.