### PR TITLE
use 'gobuildid' instead of random no for -B flag

### DIFF
--- a/crc-admin-helper.spec.in
+++ b/crc-admin-helper.spec.in
@@ -55,7 +55,7 @@ ln -fs "$(pwd)" "%{gobuilddir}/src/%{goipath}"
 
 %build
 export GOFLAGS="-mod=vendor"
-make VERSION=%{version} GO_LDFLAGS="-B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')" GO_BUILDFLAGS="-a -v -x" release
+make VERSION=%{version} GO_LDFLAGS="-B gobuildid" GO_BUILDFLAGS="-a -v -x" release
 
 %install
 # with fedora macros: gopkginstall


### PR DESCRIPTION
currently the note is a random number of 20 digits but with go1.23 the limit is 16 digits, this  uses the 'gobuildid' option for the flag which generate it from the Go build ID

this fixes the following error while building with go1.23:

```
/usr/lib/golang/pkg/tool/linux_amd64/link: -B option too long (max 16 digits): 0x93e59ccfab07a418556563adfd4bdc404b0c089b
```