### PR TITLE
Migrate golangci-lint to v2 schema

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,13 +1,24 @@
+version: "2"
 run:
   timeout: 10m
-
 linters:
   enable:
-    - errcheck
-    - goimports
-    - gofmt
-    - gosec
     - gocritic
-    - unused
+    - gosec
     - misspell
     - revive
+    - errcheck
+    - unused
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: lax

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -4,7 +4,7 @@ $(TOOLS_BINDIR)/makefat: $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR) && GOBIN=$(TOOLS_BINDIR) go install github.com/randall77/makefat
 
 $(TOOLS_BINDIR)/golangci-lint: $(TOOLS_DIR)/go.mod
-	cd $(TOOLS_DIR) && GOBIN=$(TOOLS_BINDIR) go install github.com/golangci/golangci-lint/cmd/golangci-lint
+	cd $(TOOLS_DIR) && GOBIN=$(TOOLS_BINDIR) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 
 $(TOOLS_BINDIR)/gomod2rpmdeps: $(TOOLS_DIR)/go.mod
 	cd $(TOOLS_DIR) && GOBIN=$(TOOLS_BINDIR) go install github.com/cfergeau/gomod2rpmdeps/cmd/gomod2rpmdeps


### PR DESCRIPTION
## Summary by Sourcery

Migrate golangci-lint configuration to version 2 schema and update related tooling

Enhancements:
- Refine linter configuration with new exclusion presets
- Update linter and formatter settings

Chores:
- Update golangci-lint configuration to version 2 schema
- Modify golangci-lint installation command to use v2