### PR TITLE
log: Add structured audit logs for /etc/hosts modifications

### DIFF
--- a/cmd/admin-helper/add.go
+++ b/cmd/admin-helper/add.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/crc-org/admin-helper/pkg/hosts"
+	"github.com/crc-org/admin-helper/pkg/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -24,5 +25,14 @@ func add(args []string) error {
 	if err != nil {
 		return err
 	}
-	return hosts.Add(args[0], args[1:])
+	err = hosts.Add(args[0], args[1:])
+	logger := logging.GetLogger()
+	logger.LogModification(logging.Modification{
+		Operation: "add",
+		IP:        args[0],
+		Hosts:     args[1:],
+		Caller:    cliCaller(),
+		Error:     err,
+	})
+	return err
 }

--- a/cmd/admin-helper/caller.go
+++ b/cmd/admin-helper/caller.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+)
+
+func cliCaller() string {
+	currentUser, err := user.Current()
+	if err != nil {
+		return fmt.Sprintf("cli:uid:%d", os.Getuid())
+	}
+	return "cli:" + currentUser.Username
+}

--- a/cmd/admin-helper/clean.go
+++ b/cmd/admin-helper/clean.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/crc-org/admin-helper/pkg/hosts"
+	"github.com/crc-org/admin-helper/pkg/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -24,5 +25,12 @@ func clean(args []string) error {
 	if err != nil {
 		return err
 	}
-	return hosts.Clean()
+	err = hosts.Clean()
+	logger := logging.GetLogger()
+	logger.LogModification(logging.Modification{
+		Operation: "clean",
+		Caller:    cliCaller(),
+		Error:     err,
+	})
+	return err
 }

--- a/cmd/admin-helper/remove.go
+++ b/cmd/admin-helper/remove.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/crc-org/admin-helper/pkg/hosts"
+	"github.com/crc-org/admin-helper/pkg/logging"
 	"github.com/spf13/cobra"
 )
 
@@ -23,5 +24,13 @@ func remove(args []string) error {
 	if err != nil {
 		return err
 	}
-	return hosts.Remove(args)
+	err = hosts.Remove(args)
+	logger := logging.GetLogger()
+	logger.LogModification(logging.Modification{
+		Operation: "remove",
+		Hosts:     args,
+		Caller:    cliCaller(),
+		Error:     err,
+	})
+	return err
 }

--- a/pkg/api/mux.go
+++ b/pkg/api/mux.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/crc-org/admin-helper/pkg/constants"
 	"github.com/crc-org/admin-helper/pkg/hosts"
+	"github.com/crc-org/admin-helper/pkg/logging"
 	"github.com/crc-org/admin-helper/pkg/types"
 )
 
 func Mux(hosts *hosts.Hosts) http.Handler {
 	mux := http.NewServeMux()
+	logger := logging.GetLogger()
 	mux.HandleFunc("/version", func(w http.ResponseWriter, _ *http.Request) {
 		_, _ = fmt.Fprint(w, constants.Version)
 	})
@@ -25,7 +27,15 @@ func Mux(hosts *hosts.Hosts) http.Handler {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		if err := hosts.Add(req.IP, req.Hosts); err != nil {
+		err := hosts.Add(req.IP, req.Hosts)
+		logger.LogModification(logging.Modification{
+			Operation: "add",
+			IP:        req.IP,
+			Hosts:     req.Hosts,
+			Caller:    r.RemoteAddr,
+			Error:     err,
+		})
+		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -41,7 +51,14 @@ func Mux(hosts *hosts.Hosts) http.Handler {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		if err := hosts.Remove(req.Hosts); err != nil {
+		err := hosts.Remove(req.Hosts)
+		logger.LogModification(logging.Modification{
+			Operation: "remove",
+			Hosts:     req.Hosts,
+			Caller:    r.RemoteAddr,
+			Error:     err,
+		})
+		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -57,7 +74,13 @@ func Mux(hosts *hosts.Hosts) http.Handler {
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		if err := hosts.Clean(); err != nil {
+		err := hosts.Clean()
+		logger.LogModification(logging.Modification{
+			Operation: "clean",
+			Caller:    r.RemoteAddr,
+			Error:     err,
+		})
+		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/pkg/constants/audit.go
+++ b/pkg/constants/audit.go
@@ -1,0 +1,4 @@
+package constants
+
+// LogFileEnvVar is used to direct audit logs to a file.
+const LogFileEnvVar = "ADMIN_HELPER_LOG_FILE"

--- a/pkg/logging/logging.go
+++ b/pkg/logging/logging.go
@@ -1,0 +1,63 @@
+package logging
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+
+	"github.com/crc-org/admin-helper/pkg/constants"
+)
+
+type Logger struct {
+	*slog.Logger
+}
+
+type Modification struct {
+	Operation string
+	IP        string
+	Hosts     []string
+	Caller    string
+	Error     error
+}
+
+var (
+	logger *Logger
+	once   sync.Once
+)
+
+func GetLogger() *Logger {
+	once.Do(func() {
+		logger = &Logger{slog.New(slog.NewJSONHandler(logWriter(), &slog.HandlerOptions{
+			Level: slog.LevelInfo,
+		}))}
+	})
+	return logger
+}
+
+func logWriter() io.Writer {
+	if path := os.Getenv(constants.LogFileEnvVar); path != "" {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0600)
+		if err == nil {
+			return f
+		}
+	}
+	return os.Stdout
+}
+
+func (l *Logger) LogModification(mod Modification) {
+	attrs := []any{
+		"operation", mod.Operation,
+		"caller", mod.Caller,
+	}
+	if mod.IP != "" {
+		attrs = append(attrs, "ip", mod.IP)
+	}
+	if len(mod.Hosts) > 0 {
+		attrs = append(attrs, "hosts", mod.Hosts)
+	}
+	if mod.Error != nil {
+		attrs = append(attrs, "error", mod.Error.Error())
+	}
+	l.Info("hosts modification", attrs...)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added audit logging for host modification operations (add, remove, clean) across CLI and HTTP, recording operation, targets, caller identity, and errors.
  * Introduced a centralized JSON audit logger with optional file output (configurable via environment) and unified caller resolution for consistent requester information in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


### Testing
```
gvyas@Gunjans-MacBook-Pro admin-helper % sudo ./crc-admin-helper add 127.0.0.1 test.crc.testing

{"time":"2026-06-08T17:36:10.850114+05:30","level":"INFO","msg":"hosts modification","operation":"add","caller":"cli:root","ip":"127.0.0.1","hosts":["test.crc.testing"]}
gvyas@Gunjans-MacBook-Pro admin-helper % grep "test.crc.testing" /etc/hosts || echo "removed"  

127.0.0.1        canary-openshift-ingress-canary.apps-crc.testing console-openshift-console.apps-crc.testing default-route-openshift-image-registry.apps-crc.testing downloads-openshift-console.apps-crc.testing host.crc.testing oauth-openshift.apps-crc.testing test.crc.testing
gvyas@Gunjans-MacBook-Pro admin-helper % sudo ./crc-admin-helper rm test.crc.testing           

{"time":"2026-06-08T17:36:20.42414+05:30","level":"INFO","msg":"hosts modification","operation":"remove","caller":"cli:root","hosts":["test.crc.testing"]}
gvyas@Gunjans-MacBook-Pro admin-helper % grep "test.crc.testing" /etc/hosts || echo "removed"

removed

gvyas@Gunjans-MacBook-Pro admin-helper % ./crc-admin-helper add 127.0.0.1 test.crc.testing
{"time":"2026-06-08T17:37:25.172846+05:30","level":"INFO","msg":"hosts modification","operation":"add","caller":"cli:gvyas","ip":"127.0.0.1","hosts":["test.crc.testing"],"error":"host file not writable, try running with elevated privileges"}
Error: host file not writable, try running with elevated privileges
host file not writable, try running with elevated privileges
```

Note: With sudo, caller is cli:root because Getuid() is 0. Under CRC’s binary, caller is cli:<username>