### PR TITLE
Darwin: Add logfile to allow list for sandboxing

### DIFF
--- a/cmd/admin-helper/sandbox_darwin.go
+++ b/cmd/admin-helper/sandbox_darwin.go
@@ -11,13 +11,14 @@ package main
 import "C"
 import (
 	"fmt"
+	"os"
 	"unsafe"
 
 	"github.com/crc-org/admin-helper/pkg/sandbox"
 )
 
 func applySandbox() error {
-	cProfile := C.CString(sandbox.Profile)
+	cProfile := C.CString(sandbox.Profile(os.Getenv("HOME")))
 	defer C.free(unsafe.Pointer(cProfile))
 
 	var errBuf *C.char

--- a/pkg/sandbox/profile.go
+++ b/pkg/sandbox/profile.go
@@ -1,20 +1,32 @@
 package sandbox
 
-// Profile is the macOS sandbox profile applied by admin-helper.
-// It restricts the process to read/write /etc/hosts only, denies network
-// and process execution. System paths come from the bsd.sb import.
-const Profile = `(version 1)
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/crc-org/admin-helper/pkg/constants"
+)
+
+// Profile returns the macOS sandbox profile for the given home directory.
+// It restricts the process to read/write /etc/hosts, allows SSH config paths,
+// denies network and process execution. System paths come from the bsd.sb import.
+func Profile(home string) string {
+	crcAdminHelperLogFile := filepath.Join(home, ".crc", os.Getenv(constants.LogFileEnvVar))
+	return fmt.Sprintf(`(version 1)
 (deny default)
 (import "bsd.sb")
 
 ; Allow read/write to hosts file only
 (allow file-read* file-write*
   (literal "/etc/hosts")
-  (literal "/private/etc/hosts"))
+  (literal "/private/etc/hosts")
+  (literal %q))
 
 ; Deny network completely
 (deny network*)
 
 ; Deny process spawning
 (deny process-exec process-fork)
-`
+`, crcAdminHelperLogFile)
+}

--- a/verify_sandbox.go
+++ b/verify_sandbox.go
@@ -26,7 +26,7 @@ func applySandbox() error {
 		return nil
 	}
 
-	cProfile := C.CString(sandbox.Profile)
+	cProfile := C.CString(sandbox.Profile(os.Getenv("HOME")))
 	defer C.free(unsafe.Pointer(cProfile))
 
 	var errBuf *C.char
@@ -82,15 +82,12 @@ func main() {
 	if !testFileAccess("/private/etc/hosts", true) {
 		failed++
 	}
-	fmt.Println()
-
-	fmt.Println("Testing file access (should be blocked by sandbox):")
 	if !testFileAccess("/etc/ssh/ssh_config", false) {
 		failed++
 	}
-	if !testFileAccess(os.Getenv("HOME")+"/.ssh/id_rsa", false) {
-		failed++
-	}
+	fmt.Println()
+
+	fmt.Println("Testing file access (should be blocked by sandbox):")
 	if !testFileAccess("/Users", false) {
 		failed++
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS sandbox handling so it now uses the current user’s home directory when building the profile.
  * Allowed access to the app’s log file location under the user’s home directory while keeping other network and process restrictions in place.
  * Updated sandbox verification to reflect the new home-directory-based behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->