### PR TITLE
windows: Add process-level verification to named pipe

### DIFF
--- a/cmd/admin-helper/listen_windows.go
+++ b/cmd/admin-helper/listen_windows.go
@@ -17,10 +17,14 @@ func listen() (net.Listener, error) {
 	}
 	sddl += fmt.Sprintf("(A;;GRGW;;;%s)", sid)
 
-	return winio.ListenPipe(`\\.\pipe\crc-admin-helper`, &winio.PipeConfig{
+	ln, err := winio.ListenPipe(`\\.\pipe\crc-admin-helper`, &winio.PipeConfig{
 		SecurityDescriptor: sddl,  // Administrators and system
 		MessageMode:        true,  // Use message mode so that CloseWrite() is supported
 		InputBufferSize:    65536, // Use 64KB buffers to improve performance
 		OutputBufferSize:   65536,
 	})
+	if err != nil {
+		return nil, err
+	}
+	return newVerifiedListener(ln), nil
 }

--- a/cmd/admin-helper/peercheck_windows.go
+++ b/cmd/admin-helper/peercheck_windows.go
@@ -1,0 +1,101 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/crc-org/admin-helper/pkg/logging"
+	"golang.org/x/sys/windows"
+)
+
+const allowedProcessName = "crc.exe"
+
+var allowedProcessPath = filepath.Join(os.Getenv("ProgramFiles"), "Red Hat OpenShift Local", allowedProcessName)
+
+// fdProvider is an interface for extracting the underlying file descriptor
+// from go-winio pipe connections (win32Pipe and win32MessageBytePipe both
+// embed win32File which has Fd()).
+type fdProvider interface {
+	Fd() uintptr
+}
+
+// getClientExePath resolves the connecting client's PID to its executable path.
+func getClientExePath(pipeHandle windows.Handle) (string, error) {
+	var pid uint32
+	if err := windows.GetNamedPipeClientProcessId(pipeHandle, &pid); err != nil {
+		return "", fmt.Errorf("GetNamedPipeClientProcessId: %w", err)
+	}
+
+	proc, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, pid)
+	if err != nil {
+		return "", fmt.Errorf("OpenProcess(%d): %w", pid, err)
+	}
+	defer windows.CloseHandle(proc)
+
+	buf := make([]uint16, windows.MAX_PATH)
+	size := uint32(len(buf))
+	if err := windows.QueryFullProcessImageName(proc, 0, &buf[0], &size); err != nil {
+		return "", fmt.Errorf("QueryFullProcessImageName(%d): %w", pid, err)
+	}
+
+	return windows.UTF16ToString(buf[:size]), nil
+}
+
+type verifiedListener struct {
+	net.Listener
+	logger *logging.Logger
+}
+
+func newVerifiedListener(ln net.Listener) net.Listener {
+	return &verifiedListener{
+		ln, logging.GetLogger(),
+	}
+}
+
+func (vl *verifiedListener) Accept() (net.Conn, error) {
+	for {
+		conn, err := vl.Listener.Accept()
+		if err != nil {
+			return nil, err
+		}
+
+		fd, ok := conn.(fdProvider)
+		if !ok {
+			vl.logger.Warn("peer check: connection does not expose file descriptor, rejecting")
+			conn.Close()
+			continue
+		}
+
+		exePath, err := getClientExePath(windows.Handle(fd.Fd()))
+		if err != nil {
+			vl.logger.Warn("peer check: failed to identify client process, rejecting",
+				"error", err)
+			conn.Close()
+			continue
+		}
+
+		exeName := filepath.Base(exePath)
+		if !strings.EqualFold(exeName, allowedProcessName) {
+			vl.logger.Warn("peer check: rejecting connection from unauthorized process",
+				"process", exePath,
+				"expected", allowedProcessName)
+			conn.Close()
+			continue
+		}
+
+		if !strings.EqualFold(exePath, allowedProcessPath) {
+			vl.logger.Warn("peer check: rejecting connection from process with unauthorized path",
+				"process", exePath,
+				"expected", allowedProcessPath)
+			conn.Close()
+			continue
+		}
+
+		return conn, nil
+	}
+}


### PR DESCRIPTION
The named pipe previously relied only on SDDL for access control (Administrators, SYSTEM, crc-users), allowing any process  under those identities to access the API

This adds client process verification to ensure only crc.exe can access the pipe, based on the name (crc.exe) and the  full  path under C:\Program Files

Since writing to C:\Program File requires admin privileges, full the path check cannot be satisfied without already having  admin privileges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows connection validation to accept only authorized client processes.
  * Added clearer handling for failed Windows listener creation.
  * Rejected unauthorized connections safely while continuing to accept valid ones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->